### PR TITLE
Update query_program_input.py

### DIFF
--- a/Program/query_program_input.py
+++ b/Program/query_program_input.py
@@ -84,9 +84,16 @@ for items in name_rows:
         names.append('-')
     else:
         names.append(items.get_text().strip('\n'))
+nURL = 'https://en.wikipedia.org/wiki/Messier_object'
+npage = requests.get(nURL)
+nsoup = BeautifulSoup(npage.content, 'html.parser')
+ngc=[]
+for i in range(23,1013,9):
+    ngc.append(nsoup.find_all('td')[i].get_text().strip())
 result_table.add_column(names,name="Common Name",index=3)
 result_table.add_column(mag,name="V (from SEDS)",index=8)
-
+result_table.add_column(ngc, name="NGC", index=2)
+messier_table = result_table
 
 result_table.write("messier_objects.csv", format="csv", overwrite="True")# creates a csv file
 
@@ -106,13 +113,26 @@ result_table['Type'] = np.array([
                                     for x in result_table['Type']])
 result_table['Name'] = [" ".join(x.split()) for x in result_table['Name']]
 
-# A dding constellation names
+# Adding constellation names
 coords = SkyCoord(result_table['_RAJ2000'], result_table['_DEJ2000'], unit="deg")
 const = coords.get_constellation()
 const = ['Bootes' if x == 'Boötes' else x for x in const]  # fixing for the unicode problem
 const_abr = coords.get_constellation(short_name="True")
 result_table.add_column(const, name="Constellation", index=2)
 
+result_table.add_column(np.zeros(len(result_table)), name="Messier")
+ngc_desig=[]
+for x in messier_table['NGC']:
+    ngc_desig.append(x.split(',')[0].strip())
+    try:
+        ngc_desig.append(x.split(',')[1].strip())
+    except:
+        None
+for x in ngc_desig:
+    for i in range(len(result_table)):
+        if x == result_table['Name'][i]:
+            result_table['Messier'][i]=1
+            
 # Adding an internal id number
 otype = result_table['Type']
 internal_id = [


### PR DESCRIPTION
Modified the last pull request; 
Added NGC designations column to the messier table; used them to mark messiers in NGC table

One would expect 110 messier matches in NGC and there are 110 matches but the reason is not that there are 110 messier
M 40 is not in NGC
M 45 is cluster; NGC 1432 and NGC 1435 are nebulae in the cluster so not marked
M 76 has two designations NGC 650, NGC 651 which are exact copies of each other; both marked in NGC
M 51 has two galaxies; so two NGC designations: NGC 5194, NGC 5195; both marked in NGC

I believe that the code for replacing coordinates based on character 'M' can now be removed.